### PR TITLE
Added New Joda Time and Apache Commons Lines

### DIFF
--- a/S3_TransferManager/proguard-project.txt
+++ b/S3_TransferManager/proguard-project.txt
@@ -2,14 +2,15 @@
 # using Proguard and the AWS SDK for Android
 
 -keep class org.apache.commons.logging.**               { *; }
+-keep class com.amazonaws.org.apache.commons.logging.** { *; }
 -keep class com.amazonaws.services.sqs.QueueUrlHandler  { *; }
 -keep class com.amazonaws.javax.xml.transform.sax.*     { public *; }
 -keep class com.amazonaws.javax.xml.stream.**           { *; }
 -keep class com.amazonaws.services.**.model.*Exception* { *; }
--keep class com.amazonaws.internal.** 					{ *; }
+-keep class com.amazonaws.internal.**                   { *; }
 -keep class org.codehaus.**                             { *; }
--keep class org.joda.time.tz.Provider                    { *; }
--keep class org.joda.time.tz.NameProvider                { *; }
+-keep class org.joda.time.tz.Provider                   { *; }
+-keep class org.joda.time.tz.NameProvider               { *; }
 -keepattributes Signature,*Annotation*,EnclosingMethod
 -keepnames class com.fasterxml.jackson.** { *; }
 -keepnames class com.amazonaws.** { *; }
@@ -22,6 +23,7 @@
 -dontwarn org.apache.http.annotation.**
 -dontwarn org.ietf.jgss.**
 -dontwarn org.joda.convert.**
+-dontwarn com.amazonaws.org.joda.convert.**
 -dontwarn org.w3c.dom.bootstrap.**
 
 #SDK split into multiple jars so certain classes may be referenced but not used


### PR DESCRIPTION
Amazon apparently moved the apache commons and joda time classes into their own namespace and failed to update the proguard file.