### PR TITLE
CognitoSyncClientManager - using the region constant

### DIFF
--- a/CognitoSyncDemo/src/com/amazonaws/cognito/sync/demo/CognitoSyncClientManager.java
+++ b/CognitoSyncDemo/src/com/amazonaws/cognito/sync/demo/CognitoSyncClientManager.java
@@ -61,7 +61,7 @@ public class CognitoSyncClientManager {
 
         if (useDeveloperAuthenticatedIdentities) {
             developerIdentityProvider = new DeveloperAuthenticationProvider(
-                    null, IDENTITY_POOL_ID, context, Regions.US_EAST_1);
+                    null, IDENTITY_POOL_ID, context, REGION);
             credentialsProvider = new CognitoCachingCredentialsProvider(context, developerIdentityProvider,
                     REGION);
             Log.i(TAG, "Using developer authenticated identities");


### PR DESCRIPTION
In the CognitoSync sample, 
The cognito region constant was not used for DeveloperAuthentication.