### PR TITLE
Make TransferUtility instance non-static

### DIFF
--- a/S3TransferUtilitySample/src/com/amazonaws/demo/s3transferutility/DownloadActivity.java
+++ b/S3TransferUtilitySample/src/com/amazonaws/demo/s3transferutility/DownloadActivity.java
@@ -79,13 +79,15 @@ public class DownloadActivity extends ListActivity {
      */
     private ArrayList<HashMap<String, Object>> transferRecordMaps;
     private int checkedIndex;
+    private Util util;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_download);
         // Initializes TransferUtility, always do this before using it.
-        transferUtility = Util.getTransferUtility(this);
+        util = new Util();
+        transferUtility = util.getTransferUtility(this);
         checkedIndex = INDEX_NOT_CHECKED;
         transferRecordMaps = new ArrayList<HashMap<String, Object>>();
         initUI();
@@ -120,7 +122,7 @@ public class DownloadActivity extends ListActivity {
         TransferListener listener = new DownloadListener();
         for (TransferObserver observer : observers) {
             HashMap<String, Object> map = new HashMap<String, Object>();
-            Util.fillMap(map, observer, false);
+            util.fillMap(map, observer, false);
             transferRecordMaps.add(map);
 
             // Sets listeners to in progress transfers
@@ -361,7 +363,7 @@ public class DownloadActivity extends ListActivity {
         for (int i = 0; i < observers.size(); i++) {
             observer = observers.get(i);
             map = transferRecordMaps.get(i);
-            Util.fillMap(map, observer, i == checkedIndex);
+            util.fillMap(map, observer, i == checkedIndex);
         }
         simpleAdapter.notifyDataSetChanged();
     }

--- a/S3TransferUtilitySample/src/com/amazonaws/demo/s3transferutility/DownloadSelectionActivity.java
+++ b/S3TransferUtilitySample/src/com/amazonaws/demo/s3transferutility/DownloadSelectionActivity.java
@@ -44,11 +44,13 @@ public class DownloadSelectionActivity extends ListActivity {
     // An adapter to show the objects
     private SimpleAdapter simpleAdapter;
     private ArrayList<HashMap<String, Object>> transferRecordMaps;
+    private Util util;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_download_selection);
+        util = new Util();
         initData();
         initUI();
     }
@@ -62,7 +64,7 @@ public class DownloadSelectionActivity extends ListActivity {
 
     private void initData() {
         // Gets the default S3 client.
-        s3 = Util.getS3Client(DownloadSelectionActivity.this);
+        s3 = util.getS3Client(DownloadSelectionActivity.this);
         transferRecordMaps = new ArrayList<HashMap<String, Object>>();
     }
 

--- a/S3TransferUtilitySample/src/com/amazonaws/demo/s3transferutility/UploadActivity.java
+++ b/S3TransferUtilitySample/src/com/amazonaws/demo/s3transferutility/UploadActivity.java
@@ -93,13 +93,17 @@ public class UploadActivity extends ListActivity {
     // Which row in the UI is currently checked (if any)
     private int checkedIndex;
 
+    // Reference to the utility class
+    private Util util;
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_upload);
 
         // Initializes TransferUtility, always do this before using it.
-        transferUtility = Util.getTransferUtility(this);
+        util = new Util();
+        transferUtility = util.getTransferUtility(this);
         checkedIndex = INDEX_NOT_CHECKED;
         transferRecordMaps = new ArrayList<HashMap<String, Object>>();
         initUI();
@@ -139,7 +143,7 @@ public class UploadActivity extends ListActivity {
             // transferRecordMaps which will display
             // as a single row in the UI
             HashMap<String, Object> map = new HashMap<String, Object>();
-            Util.fillMap(map, observer, false);
+            util.fillMap(map, observer, false);
             transferRecordMaps.add(map);
 
             // Sets listeners to in progress transfers
@@ -376,7 +380,7 @@ public class UploadActivity extends ListActivity {
         for (int i = 0; i < observers.size(); i++) {
             observer = observers.get(i);
             map = transferRecordMaps.get(i);
-            Util.fillMap(map, observer, i == checkedIndex);
+            util.fillMap(map, observer, i == checkedIndex);
         }
         simpleAdapter.notifyDataSetChanged();
 

--- a/S3TransferUtilitySample/src/com/amazonaws/demo/s3transferutility/Util.java
+++ b/S3TransferUtilitySample/src/com/amazonaws/demo/s3transferutility/Util.java
@@ -37,10 +37,9 @@ import java.util.UUID;
  */
 public class Util {
 
-    // We only need one instance of the clients and credentials provider
-    private static AmazonS3Client sS3Client;
-    private static CognitoCachingCredentialsProvider sCredProvider;
-    private static TransferUtility sTransferUtility;
+    private AmazonS3Client sS3Client;
+    private CognitoCachingCredentialsProvider sCredProvider;
+    private TransferUtility sTransferUtility;
 
     /**
      * Gets an instance of CognitoCachingCredentialsProvider which is
@@ -49,7 +48,7 @@ public class Util {
      * @param context An Context instance.
      * @return A default credential provider.
      */
-    private static CognitoCachingCredentialsProvider getCredProvider(Context context) {
+    private CognitoCachingCredentialsProvider getCredProvider(Context context) {
         if (sCredProvider == null) {
             sCredProvider = new CognitoCachingCredentialsProvider(
                     context.getApplicationContext(),
@@ -66,7 +65,7 @@ public class Util {
      * @param context An Context instance.
      * @return A default S3 client.
      */
-    public static AmazonS3Client getS3Client(Context context) {
+    public AmazonS3Client getS3Client(Context context) {
         if (sS3Client == null) {
             sS3Client = new AmazonS3Client(getCredProvider(context.getApplicationContext()));
             sS3Client.setRegion(Region.getRegion(Regions.fromName(Constants.BUCKET_REGION)));
@@ -81,10 +80,13 @@ public class Util {
      * @param context
      * @return a TransferUtility instance
      */
-    public static TransferUtility getTransferUtility(Context context) {
+    public TransferUtility getTransferUtility(Context context) {
         if (sTransferUtility == null) {
-            sTransferUtility = new TransferUtility(getS3Client(context.getApplicationContext()),
-                    context.getApplicationContext());
+            sTransferUtility = TransferUtility.builder()
+                    .context(context.getApplicationContext())
+                    .s3Client(getS3Client(context.getApplicationContext()))
+                    .defaultBucket(Constants.BUCKET_NAME)
+                    .build();
         }
 
         return sTransferUtility;
@@ -96,7 +98,7 @@ public class Util {
      * @param bytes number of bytes to be converted.
      * @return A string that represents the bytes in a proper scale.
      */
-    public static String getBytesString(long bytes) {
+    public String getBytesString(long bytes) {
         String[] quantifiers = new String[] {
                 "KB", "MB", "GB", "TB"
         };
@@ -121,7 +123,7 @@ public class Util {
      * @return
      * @throws IOException
      */
-    public static File copyContentUriToFile(Context context, Uri uri) throws IOException {
+    public File copyContentUriToFile(Context context, Uri uri) throws IOException {
         InputStream is = context.getContentResolver().openInputStream(uri);
         File copiedData = new File(context.getDir("SampleImagesDir", Context.MODE_PRIVATE), UUID
                 .randomUUID().toString());
@@ -144,7 +146,7 @@ public class Util {
      * Fills in the map with information in the observer so that it can be used
      * with a SimpleAdapter to populate the UI
      */
-    public static void fillMap(Map<String, Object> map, TransferObserver observer, boolean isChecked) {
+    public void fillMap(Map<String, Object> map, TransferObserver observer, boolean isChecked) {
         int progress = (int) ((double) observer.getBytesTransferred() * 100 / observer
                 .getBytesTotal());
         map.put("id", observer.getId());


### PR DESCRIPTION
This change is to demonstrate the non-static usage of TransferUtility, AmazonS3Client and credentials provider instances. 