### PR TITLE
[KinesisVideo] Update gradle; Fix set region in client fixes #214

### DIFF
--- a/AmazonKinesisVideoDemoApp/README.md
+++ b/AmazonKinesisVideoDemoApp/README.md
@@ -47,4 +47,4 @@
 
 ## 3. Paste
   * You will need all the information from the above steps that have :clipboard: and paste them into this file on your local copy [awsconfiguration.json](src/main/res/raw/awsconfiguration.json)
-  * Change the region that the app will stream to by editing this [line of code](https://github.com/awslabs/aws-sdk-android-samples/blob/master/AmazonKinesisVideoDemoApp/src/main/java/com/amazonaws/kinesisvideo/demoapp/fragment/StreamingFragment.java#L64)
+  * Change the region that the app will stream to by editing this [line of code](https://github.com/awslabs/aws-sdk-android-samples/blob/master/AmazonKinesisVideoDemoApp/src/main/java/com/amazonaws/kinesisvideo/demoapp/KinesisVideoDemoApp.java#L17)

--- a/AmazonKinesisVideoDemoApp/build.gradle
+++ b/AmazonKinesisVideoDemoApp/build.gradle
@@ -1,10 +1,11 @@
 buildscript {
     repositories {
+        google()
         jcenter()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.android.tools.build:gradle:3.1.2'
     }
 }
 
@@ -12,35 +13,20 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 24
-    buildToolsVersion '26.0.2'
     defaultConfig {
         applicationId "com.amazonaws.kinesisvideo.demoapp"
-        minSdkVersion 21
+        minSdkVersion 23
         targetSdkVersion 24
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
         multiDexEnabled true
-
-        ndk {
-            abiFilters 'x86', 'x86_64', 'armeabi', 'armeabi-v7a', 'arm64-v8a'
-            ldLibs "log"
-        }
     }
 
     buildTypes {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
-        }
-    }
-
-    splits {
-        abi {
-            enable false
-            reset()
-            include 'x86', 'x86_64', 'armeabi', 'armeabi-v7a', 'arm64-v8a'
-            universalApk true
         }
     }
 
@@ -59,14 +45,17 @@ repositories {
     mavenCentral()
 }
 
+def aws_version = '2.6.+'
+def android_library_version = '24.2.1'
+
 dependencies {
-    compile ('com.amazonaws:aws-android-sdk-kinesisvideo:2.6.+@aar') { transitive = true; }
-    compile ('com.amazonaws:aws-android-sdk-auth-ui:2.6.+@aar') { transitive = true; }
-    compile ('com.amazonaws:aws-android-sdk-auth-userpools:2.6.+@aar') { transitive = true; }
-    compile 'com.android.support:support-v4:24.2.1'
-    compile 'com.android.support:appcompat-v7:24.2.1'
-    compile 'com.android.support:design:24.2.1'
-    compile 'com.android.support.constraint:constraint-layout:1.0.2'
-    testCompile 'junit:junit:4.12'
-    androidTestCompile 'junit:junit:4.12'
+    implementation ("com.amazonaws:aws-android-sdk-kinesisvideo:$aws_version@aar") { transitive = true }
+    implementation ("com.amazonaws:aws-android-sdk-auth-ui:$aws_version@aar") { transitive = true }
+    implementation ("com.amazonaws:aws-android-sdk-auth-userpools:$aws_version@aar") { transitive = true }
+    implementation "com.android.support:support-v4:$android_library_version"
+    implementation "com.android.support:appcompat-v7:$android_library_version"
+    implementation "com.android.support:design:$android_library_version"
+    implementation 'com.android.support.constraint:constraint-layout:1.0.2'
+    testImplementation 'junit:junit:4.12'
+    androidTestImplementation 'junit:junit:4.12'
 }

--- a/AmazonKinesisVideoDemoApp/gradle/wrapper/gradle-wrapper.properties
+++ b/AmazonKinesisVideoDemoApp/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Jan 08 13:57:47 PST 2018
+#Fri May 18 09:24:20 PDT 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip

--- a/AmazonKinesisVideoDemoApp/src/main/java/com/amazonaws/kinesisvideo/demoapp/KinesisVideoDemoApp.java
+++ b/AmazonKinesisVideoDemoApp/src/main/java/com/amazonaws/kinesisvideo/demoapp/KinesisVideoDemoApp.java
@@ -6,6 +6,7 @@ import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.mobile.auth.core.IdentityManager;
 import com.amazonaws.mobile.auth.userpools.CognitoUserPoolsSignInProvider;
 import com.amazonaws.mobile.config.AWSConfiguration;
+import com.amazonaws.regions.Regions;
 
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -13,6 +14,7 @@ import java.util.logging.Logger;
 import static com.amazonaws.util.StringUtils.isBlank;
 
 public class KinesisVideoDemoApp extends Application {
+    public static Regions KINESIS_VIDEO_REGION = Regions.US_WEST_2;
 
     @Override
     public void onCreate() {

--- a/AmazonKinesisVideoDemoApp/src/main/java/com/amazonaws/kinesisvideo/demoapp/fragment/StreamConfigurationFragment.java
+++ b/AmazonKinesisVideoDemoApp/src/main/java/com/amazonaws/kinesisvideo/demoapp/fragment/StreamConfigurationFragment.java
@@ -67,7 +67,10 @@ public class StreamConfigurationFragment extends Fragment {
         final View view = inflater.inflate(R.layout.fragment_stream_configuration, container, false);
 
         try {
-            mKinesisVideoClient = KinesisVideoAndroidClientFactory.createKinesisVideoClient(getActivity(),KinesisVideoDemoApp.getCredentialsProvider());
+            mKinesisVideoClient = KinesisVideoAndroidClientFactory.createKinesisVideoClient(
+                    getActivity(),
+                    KinesisVideoDemoApp.KINESIS_VIDEO_REGION,
+                    KinesisVideoDemoApp.getCredentialsProvider());
         } catch (KinesisVideoException e) {
             Log.e(TAG, "Failed to create Kinesis Video client", e);
         }

--- a/AmazonKinesisVideoDemoApp/src/main/java/com/amazonaws/kinesisvideo/demoapp/fragment/StreamingFragment.java
+++ b/AmazonKinesisVideoDemoApp/src/main/java/com/amazonaws/kinesisvideo/demoapp/fragment/StreamingFragment.java
@@ -12,6 +12,7 @@ import android.view.ViewGroup;
 import android.widget.Button;
 import android.widget.Toast;
 
+import com.amazonaws.kinesisvideo.client.KinesisVideoClientConfiguration;
 import com.amazonaws.kinesisvideo.common.exception.KinesisVideoException;
 import com.amazonaws.kinesisvideo.demoapp.KinesisVideoDemoApp;
 import com.amazonaws.kinesisvideo.demoapp.R;
@@ -61,7 +62,7 @@ public class StreamingFragment extends Fragment implements TextureView.SurfaceTe
         try {
             mKinesisVideoClient = KinesisVideoAndroidClientFactory.createKinesisVideoClient(
                     getActivity(),
-                    Regions.US_WEST_2,
+                    KinesisVideoDemoApp.KINESIS_VIDEO_REGION,
                     KinesisVideoDemoApp.getCredentialsProvider());
 
             mCameraMediaSource = (AndroidCameraMediaSource) mKinesisVideoClient


### PR DESCRIPTION
Kinesis Video client uses single instance approach when initialized from convenience methods. First creation in the configuration fragment initialized with default region instead of developer specified region.