### PR TITLE
Add Cognito Identity Id to InteractionConfig during setup

### DIFF
--- a/LexSample/app/src/main/java/com/amazonaws/sample/lex/InteractiveVoiceActivity.java
+++ b/LexSample/app/src/main/java/com/amazonaws/sample/lex/InteractiveVoiceActivity.java
@@ -64,9 +64,14 @@ public class InteractiveVoiceActivity extends Activity
             public void onResult(UserStateDetails result) {
                 Log.d(TAG, "onResult: ");
                 voiceView.getViewAdapter().setCredentialProvider(AWSMobileClient.getInstance());
-                voiceView.getViewAdapter().setInteractionConfig(
-                        new InteractionConfig(appContext.getString(R.string.bot_name),
-                                appContext.getString(R.string.bot_alias)));
+
+                String identityId = AWSMobileClient.getInstance().getIdentityId();
+                InteractionConfig lexInteractionConfig = new InteractionConfig(
+                        appContext.getString(R.string.bot_name),
+                        appContext.getString(R.string.bot_alias),
+                        identityId);
+                voiceView.getViewAdapter().setInteractionConfig(lexInteractionConfig);
+
                 voiceView.getViewAdapter().setAwsRegion(appContext.getString(R.string.lex_region));
             }
 

--- a/LexSample/app/src/main/java/com/amazonaws/sample/lex/TextActivity.java
+++ b/LexSample/app/src/main/java/com/amazonaws/sample/lex/TextActivity.java
@@ -170,7 +170,7 @@ public class TextActivity extends Activity {
             AWSMobileClient.getInstance().getAWSCredentials(new Callback<AWSCredentials>() {
                 @Override
                 public void onResult(AWSCredentials result) {
-                    Log.d(TAG, "getAWSCredentials.onResult, credentials: " + result.toString());
+                    Log.d(TAG, "obtained AWS credentials successfully.");
                     getCredentialsLatch.countDown();
                 }
 

--- a/LexSample/app/src/main/java/com/amazonaws/sample/lex/TextActivity.java
+++ b/LexSample/app/src/main/java/com/amazonaws/sample/lex/TextActivity.java
@@ -25,10 +25,12 @@ import android.widget.EditText;
 import android.widget.ListView;
 import android.widget.Toast;
 
+import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.mobile.client.AWSMobileClient;
 import com.amazonaws.mobile.client.Callback;
 import com.amazonaws.mobile.client.UserStateDetails;
 import com.amazonaws.mobileconnectors.lex.interactionkit.InteractionClient;
+import com.amazonaws.mobileconnectors.lex.interactionkit.config.InteractionConfig;
 import com.amazonaws.mobileconnectors.lex.interactionkit.Response;
 import com.amazonaws.mobileconnectors.lex.interactionkit.continuations.LexServiceContinuation;
 import com.amazonaws.mobileconnectors.lex.interactionkit.listeners.AudioPlaybackListener;
@@ -98,7 +100,6 @@ public class TextActivity extends Activity {
             }
         }
     };
-    private int file_count = 0;
 
     @Override
     protected void onCreate(final Bundle savedInstanceState) {
@@ -143,33 +144,68 @@ public class TextActivity extends Activity {
     private void initializeLexSDK() {
         Log.d(TAG, "Lex Client");
 
+        final CountDownLatch initializeLatch = new CountDownLatch(1);
+        final CountDownLatch getCredentialsLatch = new CountDownLatch(1);
+
         // Initialize the mobile client
         AWSMobileClient.getInstance().initialize(this, new Callback<UserStateDetails>() {
             @Override
             public void onResult(UserStateDetails result) {
-                Log.d(TAG, "onResult: ");
-                // Create Lex interaction client.
-                lexInteractionClient = new InteractionClient(getApplicationContext(),
-                        AWSMobileClient.getInstance(),
-                        Regions.fromName(appContext.getResources().getString(R.string.lex_region)),
-                        appContext.getResources().getString(R.string.bot_name),
-                        appContext.getResources().getString(R.string.bot_alias));
-                lexInteractionClient.setAudioPlaybackListener(audioPlaybackListener);
-                lexInteractionClient.setInteractionListener(interactionListener);
+                Log.d(TAG, "initialize.onResult, userState: " + result.getUserState().toString());
+                initializeLatch.countDown();
             }
 
             @Override
             public void onError(Exception e) {
-                Log.e(TAG, "onError: ", e);
+                Log.e(TAG, "initialize.onError: ", e);
+                initializeLatch.countDown();
             }
         });
+
+        try {
+            initializeLatch.await();
+
+            // Identity ID is not available until we make a call to get credentials, which also
+            // caches identity ID.
+            AWSMobileClient.getInstance().getAWSCredentials(new Callback<AWSCredentials>() {
+                @Override
+                public void onResult(AWSCredentials result) {
+                    Log.d(TAG, "getAWSCredentials.onResult, credentials: " + result.toString());
+                    getCredentialsLatch.countDown();
+                }
+
+                @Override
+                public void onError(Exception e) {
+                    Log.e(TAG, "getAWSCredentials.onError: ", e);
+                    getCredentialsLatch.countDown();
+                }
+            });
+
+            getCredentialsLatch.await();
+            String identityId = AWSMobileClient.getInstance().getIdentityId();
+            Log.d(TAG, "identityId: " + identityId);
+
+            InteractionConfig lexInteractionConfig = new InteractionConfig(
+                    appContext.getResources().getString(R.string.bot_name),
+                    appContext.getResources().getString(R.string.bot_alias),
+                    identityId);
+
+            lexInteractionClient = new InteractionClient(getApplicationContext(),
+                    AWSMobileClient.getInstance(),
+                    Regions.fromName(appContext.getResources().getString(R.string.lex_region)),
+                    lexInteractionConfig);
+
+            lexInteractionClient.setAudioPlaybackListener(audioPlaybackListener);
+            lexInteractionClient.setInteractionListener(interactionListener);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
     }
 
     /**
      * Read user text input.
      */
     private void textEntered() {
-        // showToast("Text input not implemented");
         String text = userTextInput.getText().toString();
         if (!inConversation) {
             Log.d(TAG, " -- New conversation started");


### PR DESCRIPTION
Current LexSample doesn't work with Mobile Client. This change adds `CountdownLatch`es in the text sample to ensure we are initialized, and have made one successful network call, before we attempt to retrieve the current identity ID and set it in the `InteractionConfig`.

I did not update `InteractiveVoiceActivity.java` to have the same initialization setup. That means if a customer runs the sample with voice first, it will likely fail (unless there is some initialization I'm not aware of in the Lex adapter). The workaround is to run the text sample first, which will initialize and cache the identity ID locally. Subsequent invocations of the voice sample should work as expected.