### PR TITLE
Update README + sample build.gradle with correct steps to use aws-android-sdk-cognitoauth

### DIFF
--- a/AmazonCognitoAuthDemo/README.md
+++ b/AmazonCognitoAuthDemo/README.md
@@ -52,7 +52,7 @@ Add the following dependencies to your `app/build.gradle`.
 ***AWS Android Cognito Auth*** The SDK with sign-in and sign-up functions `aws-android-sdk-cognitoauth`
 ```
 dependency {
-  compile 'com.amazonaws:aws-android-sdk-cognitoauth:2.7.+@aar'
+  implementation ('com.amazonaws:aws-android-sdk-cognitoauth:2.9.+@aar') { transitive = true }
 }
 ```
 To add other AWS Android SDK's in your app read the [Guide for AWS Android Mobile SDK](http://docs.aws.amazon.com/mobile/sdkforandroid/developerguide/setup.html).
@@ -61,10 +61,14 @@ To add other AWS Android SDK's in your app read the [Guide for AWS Android Mobil
 ***Chrome Custom Tabs*** This SDK opens Cognito's hosted webpage's on Chrome.<br/>
 ```
 dependency {
-  compile 'com.android.support:customtabs:25.0.0+'
+  implementation 'com.android.support:customtabs:25.0.0+'
 }
 ```
 **Note** Chrome is required on the Android device to use this SDK.
+
+***Maven Central Repo***
+
+To use the latest versions of aws-android-sdk-cognitoauth, you will need to add `mavenCentral()` to the list of repositories in your top-level `build.gradle` file.
 
 ## Instantiate Cognito Auth
 Create a new instance of `Auth` with the following userpool settings.

--- a/AmazonCognitoAuthDemo/build.gradle
+++ b/AmazonCognitoAuthDemo/build.gradle
@@ -17,6 +17,7 @@ allprojects {
     repositories {
         jcenter()
         google()
+        mavenCentral()
     }
 }
 


### PR DESCRIPTION
Updated a few things that were outdated in the AmazonCognitoAuthDemo. As you can see [here](https://bintray.com/bintray/jcenter/com.amazonaws%3Aaws-android-sdk-cognitoauth), jcenter does not have the latest versions (2.9+) of aws-android-sdk-cognitoauth. But mavenCentral [does](http://central.maven.org/maven2/com/amazonaws/aws-android-sdk-cognitoauth/). As a new user it took me a while to figure out what the issue was when the sample code didn't work.