### PR TITLE
Update gradle and add required support libraries

### DIFF
--- a/AmazonCognitoAuthDemo/app/build.gradle
+++ b/AmazonCognitoAuthDemo/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion '27.0.3'
     defaultConfig {
         applicationId "com.amazonaws.cognito.android.samples.authdemo"
         minSdkVersion 21

--- a/AmazonCognitoAuthDemo/build.gradle
+++ b/AmazonCognitoAuthDemo/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.1'
+        classpath 'com.android.tools.build:gradle:3.2.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/AmazonCognitoAuthDemo/gradle/wrapper/gradle-wrapper.properties
+++ b/AmazonCognitoAuthDemo/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Apr 19 09:43:17 PDT 2018
+#Fri Dec 21 14:39:29 PST 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip

--- a/AmazonCognitoYourUserPoolsDemo/app/build.gradle
+++ b/AmazonCognitoYourUserPoolsDemo/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 23
-    buildToolsVersion '25.0.0'
 
     defaultConfig {
         applicationId "com.amazonaws.youruserpools.CognitoYourUserPoolsDemo"

--- a/AmazonCognitoYourUserPoolsDemo/build.gradle
+++ b/AmazonCognitoYourUserPoolsDemo/build.gradle
@@ -3,9 +3,10 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.3'
+        classpath 'com.android.tools.build:gradle:3.2.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/AmazonCognitoYourUserPoolsDemo/gradle/wrapper/gradle-wrapper.properties
+++ b/AmazonCognitoYourUserPoolsDemo/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Nov 08 20:11:44 PST 2017
+#Fri Dec 21 14:31:04 PST 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip

--- a/AndroidPubSub/build.gradle
+++ b/AndroidPubSub/build.gradle
@@ -21,7 +21,7 @@ dependencies {
     def aws_version = "2.9.+"
     implementation "com.amazonaws:aws-android-sdk-iot:$aws_version"
     implementation "com.amazonaws:aws-android-sdk-mobile-client:$aws_version"
-    implementation "com.android.support:support-compat:28.0.0-alpha1"
+    implementation "com.android.support:support-compat:28.0.0"
 }
 
 android {

--- a/AndroidPubSub/build.gradle
+++ b/AndroidPubSub/build.gradle
@@ -21,6 +21,7 @@ dependencies {
     def aws_version = "2.9.+"
     implementation "com.amazonaws:aws-android-sdk-iot:$aws_version"
     implementation "com.amazonaws:aws-android-sdk-mobile-client:$aws_version"
+    implementation "com.android.support:support-compat:28.0.0-alpha1"
 }
 
 android {

--- a/AndroidPubSubWebSocket/build.gradle
+++ b/AndroidPubSubWebSocket/build.gradle
@@ -21,7 +21,7 @@ dependencies {
     def aws_version = "2.9.+"
     implementation "com.amazonaws:aws-android-sdk-iot:$aws_version"
     implementation "com.amazonaws:aws-android-sdk-mobile-client:$aws_version"
-    implementation "com.android.support:support-compat:28.0.0-alpha1"
+    implementation "com.android.support:support-compat:28.0.0"
 }
 
 android {

--- a/AndroidPubSubWebSocket/build.gradle
+++ b/AndroidPubSubWebSocket/build.gradle
@@ -21,6 +21,7 @@ dependencies {
     def aws_version = "2.9.+"
     implementation "com.amazonaws:aws-android-sdk-iot:$aws_version"
     implementation "com.amazonaws:aws-android-sdk-mobile-client:$aws_version"
+    implementation "com.android.support:support-compat:28.0.0-alpha1"
 }
 
 android {

--- a/S3TransferUtilitySample/build.gradle
+++ b/S3TransferUtilitySample/build.gradle
@@ -25,6 +25,7 @@ dependencies {
         exclude group: 'com.android.support', module: 'support-annotations'
     }
     implementation 'com.android.support.test:rules:1.0.2'
+    implementation "com.android.support:support-compat:28.0.0-alpha1"
 }
 
 android {

--- a/S3TransferUtilitySample/build.gradle
+++ b/S3TransferUtilitySample/build.gradle
@@ -25,7 +25,7 @@ dependencies {
         exclude group: 'com.android.support', module: 'support-annotations'
     }
     implementation 'com.android.support.test:rules:1.0.2'
-    implementation "com.android.support:support-compat:28.0.0-alpha1"
+    implementation "com.android.support:support-compat:28.0.0"
 }
 
 android {


### PR DESCRIPTION
Summary of changes:
1. Update Android Gradle plugin to 3.2.1
2. Add dependency on support library required by AWSMobileClient to check if ACCESS_NETWORK_STATE is needed. 