### PR TITLE
change minisdkversion of s3sample from 19 to 23

### DIFF
--- a/S3TransferUtilitySample/build.gradle
+++ b/S3TransferUtilitySample/build.gradle
@@ -36,7 +36,7 @@ android {
     defaultConfig {
         versionCode 1
         versionName "1.0.0"
-        minSdkVersion 16
+        minSdkVersion 23
         targetSdkVersion 28
         testInstrumentationRunner = 'android.support.test.runner.AndroidJUnitRunner'
     }

--- a/S3TransferUtilitySample/build.gradle
+++ b/S3TransferUtilitySample/build.gradle
@@ -36,7 +36,7 @@ android {
     defaultConfig {
         versionCode 1
         versionName "1.0.0"
-        minSdkVersion 23
+        minSdkVersion 16
         targetSdkVersion 28
         testInstrumentationRunner = 'android.support.test.runner.AndroidJUnitRunner'
     }

--- a/S3TransferUtilitySample/build.gradle
+++ b/S3TransferUtilitySample/build.gradle
@@ -18,9 +18,11 @@ buildscript {
 apply plugin: 'com.android.application'
 
 dependencies {
+//BEGIN AWS DEPENDENCIES
     def aws_version = "2.11.+"
     implementation "com.amazonaws:aws-android-sdk-s3:$aws_version"
     implementation ("com.amazonaws:aws-android-sdk-mobile-client:$aws_version") { transitive = true }
+//END AWS DEPENDENCIES    
     implementation 'com.android.support.test.espresso:espresso-core:3.0.2', {
         exclude group: 'com.android.support', module: 'support-annotations'
     }
@@ -34,7 +36,7 @@ android {
     defaultConfig {
         versionCode 1
         versionName "1.0.0"
-        minSdkVersion 19
+        minSdkVersion 23
         targetSdkVersion 28
         testInstrumentationRunner = 'android.support.test.runner.AndroidJUnitRunner'
     }

--- a/S3TransferUtilitySample/build.gradle
+++ b/S3TransferUtilitySample/build.gradle
@@ -36,6 +36,7 @@ android {
     defaultConfig {
         versionCode 1
         versionName "1.0.0"
+        // aws-android-sdk-mobile-client depends on aws-android-sdk-auth-ui which requires a minSdkVersion of 23
         minSdkVersion 23
         targetSdkVersion 28
         testInstrumentationRunner = 'android.support.test.runner.AndroidJUnitRunner'


### PR DESCRIPTION
1. Change minisdkversion of s3sample from 19 to 23 to avoid build failure. aws-android-sdk-auth-ui has minisdkversion=23, it requires the test app has minisdkversion at least 23.

2. Add  //BEGIN AWS DEPENDENCIES and //END AWS DEPENDENCIES  to enclose aws dependencies so that get our test code to be easy to replace them with local libarary