### PR TITLE
AndroidPubSub Sample does not work!!!

### DIFF
--- a/AndroidPubSub/README.md
+++ b/AndroidPubSub/README.md
@@ -87,12 +87,6 @@ This sample demonstrates the use of the AWS IoT APIs to securely publish-to and 
     The customer specific endpoint can be found on the IoT console settings page. Navigate to the [AWS IoT Console](https://console.aws.amazon.com/iot/home) and press the `Settings` button.
 
     ```
-    COGNITO_POOL_ID = "<CHANGE_ME>";
-    MY_REGION = Regions.US_EAST_1;
-    ```
-    This would be the name of the Cognito pool ID and the Region that you noted down previously. 
-
-    ```
     AWS_IOT_POLICY_NAME = "CHANGE_ME";
     ```
     This would be the name of the AWS IoT policy that you created previously. 
@@ -105,6 +99,13 @@ This sample demonstrates the use of the AWS IoT APIs to securely publish-to and 
     For these parameters, the default values will work for the sample application.  The keystore name is the name used when writing the keystore file to the application's file directory.  The password is the password given to protect the keystore when written.  Certificate ID is the alias in the keystore for the certificate and private key entry.  
 
    **Note**: If you end up creating a keystore off of the device you will need to update this to match the alias given when importing the certificate into the keystore.
+
+1. Open `res/raw/awsconfiguration.json` and update the values for `PoolId` with the ID of the Cognito Identity Pool created above and `Region` with the region of the Cognito Identity Pool created above (for example us-east-1):
+
+    ```
+    "PoolId": "REPLACE_ME",
+    "Region": "REPLACE_ME"
+    ```
 
 1. Build and run the sample app.
 

--- a/AndroidPubSub/README.md
+++ b/AndroidPubSub/README.md
@@ -84,7 +84,7 @@ This sample demonstrates the use of the AWS IoT APIs to securely publish-to and 
     ```
     MY_REGION = Regions.US_EAST_1;
     ```
-    This would be the name of the Region that you noted down previously.
+    This would be the name of the IoT region that you noted down previously.
 
     ```
     CUSTOMER_SPECIFIC_ENDPOINT = "<CHANGE_ME>";

--- a/AndroidPubSub/README.md
+++ b/AndroidPubSub/README.md
@@ -82,6 +82,11 @@ This sample demonstrates the use of the AWS IoT APIs to securely publish-to and 
 1. Open `PubSubActivity.java` and update the following constants:
 
     ```
+    MY_REGION = Regions.US_EAST_1;
+    ```
+    This would be the name of the Region that you noted down previously.
+
+    ```
     CUSTOMER_SPECIFIC_ENDPOINT = "<CHANGE_ME>";
     ```
     The customer specific endpoint can be found on the IoT console settings page. Navigate to the [AWS IoT Console](https://console.aws.amazon.com/iot/home) and press the `Settings` button.


### PR DESCRIPTION
Followed the instruction https://github.com/awslabs/aws-sdk-android-samples/tree/master/AndroidPubSub to set the parameter on the AWS cloud

Downloaded the whole code from https://github.com/awslabs/aws-sdk-android-samples

Used Android Studio 3.3.1 to open the folder AndroidPubSub

Changed the following part
PubSubActivity.java
// IoT endpoint
// AWS Iot CLI describe-endpoint call returns: XXXXXXXXXX.iot.<region>.amazonaws.com
private static final String CUSTOMER_SPECIFIC_ENDPOINT = "REPLACE_ME";
// Name of the AWS IoT policy to attach to a newly created certificate
private static final String AWS_IOT_POLICY_NAME = "REPLACE_ME";

awsconfiguration.json
"PoolId": "REPLACE_ME",
"Region": "Regions.US_EAST_1"

Sync, Build and Run App on emulator9.0 or Mobile Phone8.0, the result in Logcat is 

com.amazonaws.demo.androidpubsub W/o.androidpubsu: Verification of com.amazonaws.logging.Log com.amazonaws.logging.LogFactory.getLog(java.lang.String) took 100.996ms
com.amazonaws.demo.androidpubsub E/com.amazonaws.demo.androidpubsub.PubSubActivity: onError: 
    java.lang.RuntimeException: Failed to initialize Cognito Identity; please check your awsconfiguration.json
        at com.amazonaws.mobile.client.AWSMobileClient$2.run(AWSMobileClient.java:402)
        at com.amazonaws.mobile.client.internal.InternalCallback$1.run(InternalCallback.java:101)
        at java.lang.Thread.run(Thread.java:764)
     Caused by: java.lang.IllegalArgumentException: Failed to read CognitoIdentity please check your setup or awsconfiguration.json file
        at com.amazonaws.auth.CognitoCredentialsProvider.getRegions(CognitoCredentialsProvider.java:195)
        at com.amazonaws.auth.CognitoCredentialsProvider.<init>(CognitoCredentialsProvider.java:174)
        at com.amazonaws.auth.CognitoCachingCredentialsProvider.<init>(CognitoCachingCredentialsProvider.java:228)
        at com.amazonaws.mobile.client.AWSMobileClient$2.run(AWSMobileClient.java:400)
        at com.amazonaws.mobile.client.internal.InternalCallback$1.run(InternalCallback.java:101) 
        at java.lang.Thread.run(Thread.java:764) 
     Caused by: java.lang.IllegalArgumentException: Cannot create enum from Regions.US_EAST_1 value!
        at com.amazonaws.regions.Regions.fromName(Regions.java:114)
        at com.amazonaws.auth.CognitoCredentialsProvider.getRegions(CognitoCredentialsProvider.java:193)
        at com.amazonaws.auth.CognitoCredentialsProvider.<init>(CognitoCredentialsProvider.java:174) 
        at com.amazonaws.auth.CognitoCachingCredentialsProvider.<init>(CognitoCachingCredentialsProvider.java:228) 
        at com.amazonaws.mobile.client.AWSMobileClient$2.run(AWSMobileClient.java:400) 
        at com.amazonaws.mobile.client.internal.InternalCallback$1.run(InternalCallback.java:101) 
        at java.lang.Thread.run(Thread.java:764) 

Seems that the AWS modules do not work in the App.

How to deal with this problem?
Should there some other code be added?