### PR TITLE
Guard against empty inputs

### DIFF
--- a/LexSample/app/src/main/java/com/amazonaws/sample/lex/TextActivity.java
+++ b/LexSample/app/src/main/java/com/amazonaws/sample/lex/TextActivity.java
@@ -25,7 +25,6 @@ import android.widget.EditText;
 import android.widget.ListView;
 import android.widget.Toast;
 
-import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.mobile.client.AWSMobileClient;
 import com.amazonaws.mobile.client.Callback;
 import com.amazonaws.mobile.client.UserStateDetails;
@@ -43,7 +42,6 @@ import org.json.JSONObject;
 
 import java.text.DateFormat;
 import java.util.Date;
-import java.util.concurrent.CountDownLatch;
 
 public class TextActivity extends Activity {
     private static final String TAG = "TextActivity";
@@ -202,6 +200,12 @@ public class TextActivity extends Activity {
      */
     private void textEntered() {
         String text = userTextInput.getText().toString();
+
+        if (text == null || text.trim().equals("")) {
+            Log.d(TAG, "text null or empty");
+            return;
+        }
+
         if (!inConversation) {
             Log.d(TAG, " -- New conversation started");
             startNewConversation();


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

We occasionally saw crashes where multiple taps on the keyboard's done/enter button would throw the app into a state where it would attempt to submit an empty request. 

Long term, the sample should have better state handling to protect against the conversation flow being attempted while the client is busy with another request, and serialize requests so we don't attempt to submit multiple concurrent requests during a conversation. But this is a simple guard that at least protects against unexpected null or empty text inputs.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
