### PR TITLE
Update AmazonKinesisVideoDemoApp dependency version

### DIFF
--- a/AmazonKinesisVideoDemoApp/build.gradle
+++ b/AmazonKinesisVideoDemoApp/build.gradle
@@ -47,18 +47,21 @@ repositories {
     mavenCentral()
 }
 
-def aws_version = '2.13.+'
-def android_library_version = '26.1.0'
 
 dependencies {
+    def aws_version = '2.14.+'
+
     implementation ("com.amazonaws:aws-android-sdk-kinesisvideo:$aws_version@aar") { transitive = true }
     implementation ("com.amazonaws:aws-android-sdk-mobile-client:$aws_version@aar") { transitive = true }
     implementation ("com.amazonaws:aws-android-sdk-auth-ui:$aws_version@aar") { transitive = true }
     implementation ("com.amazonaws:aws-android-sdk-auth-userpools:$aws_version@aar") { transitive = true }
+
+    def android_library_version = '26.1.0'
     implementation "com.android.support:support-v4:$android_library_version"
     implementation "com.android.support:appcompat-v7:$android_library_version"
     implementation "com.android.support:design:$android_library_version"
     implementation 'com.android.support.constraint:constraint-layout:1.1.3'
+
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'junit:junit:4.12'
 }


### PR DESCRIPTION
*Issue #, if available:*

As @zhiyua-git pointed out in https://github.com/aws-amplify/aws-sdk-android/issues/1065#issuecomment-516528747 , the script we use to update sample app dependency versions didn't catch the `build.gradle` for AmazonKinesisVideoDemoApp. The script should be a bit more forgiving, but this PR also brings the formatting into line with other samples.

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
