### PR TITLE
Clarify usage of Ids & Secrets

### DIFF
--- a/AmazonCognitoYourUserPoolsDemo/app/src/main/java/com/amazonaws/youruserpools/AppHelper.java
+++ b/AmazonCognitoYourUserPoolsDemo/app/src/main/java/com/amazonaws/youruserpools/AppHelper.java
@@ -75,6 +75,10 @@ public class AppHelper {
     private static List<ItemToDisplay> mfaOptions;
     private static List<String> mfaAllOptionsCode;
 
+    // The lines below allow app users to register in your Cognito User Pool. Use
+    // a Cognito Identity Pool to control the user's access to your account resources.
+    // https://docs.aws.amazon.com/cognito/latest/developerguide/what-is-amazon-cognito.html
+
     // Change the next three lines of code to run this demo on your user pool
 
     /**


### PR DESCRIPTION
Clarifies usage of userPoolId, clientId, clientSecret by noting that they provide the ability for a user to register into a UserPool, but do not in themselves provide access to service resources.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
