### PR TITLE
Update S3TransferUtilitySampleApp targetSdkVersion to 29

### DIFF
--- a/S3TransferUtilitySample/AndroidManifest.xml
+++ b/S3TransferUtilitySample/AndroidManifest.xml
@@ -5,16 +5,13 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
-    
-    
-    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 
     <application
         android:name=".MyApplication"
         android:allowBackup="true"
         android:icon="@drawable/ic_launcher"
-        android:label="@string/app_name" >
+        android:label="@string/app_name"
+        >
         <activity android:name="com.amazonaws.demo.s3transferutility.MainActivity" >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/S3TransferUtilitySample/AndroidManifest.xml
+++ b/S3TransferUtilitySample/AndroidManifest.xml
@@ -10,8 +10,7 @@
         android:name=".MyApplication"
         android:allowBackup="true"
         android:icon="@drawable/ic_launcher"
-        android:label="@string/app_name"
-        >
+        android:label="@string/app_name">
         <activity android:name="com.amazonaws.demo.s3transferutility.MainActivity" >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/S3TransferUtilitySample/S3TransferUtilityTutorial.md
+++ b/S3TransferUtilitySample/S3TransferUtilityTutorial.md
@@ -359,7 +359,7 @@ All we need to do to download a file is to specify where we want the file placed
 private void beginDownload(String key) {
     // Location to download files from S3 to. You can choose any accessible
     // file.
-    File file = new File(Environment.getExternalStorageDirectory().toString() + "/" + key);
+    File file = new File(getExternalFilesDir(null).toString() + "/" + key);
 
     // Initiate the download
     TransferObserver observer = transferUtility.download(Constants.BUCKET_NAME, key, file);

--- a/S3TransferUtilitySample/build.gradle
+++ b/S3TransferUtilitySample/build.gradle
@@ -32,14 +32,14 @@ dependencies {
 }
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 29
 
     defaultConfig {
         versionCode 1
         versionName "1.0.0"
         // aws-android-sdk-mobile-client depends on aws-android-sdk-auth-ui which requires a minSdkVersion of 23
         minSdkVersion 23
-        targetSdkVersion 28
+        targetSdkVersion 29
         testInstrumentationRunner = 'android.support.test.runner.AndroidJUnitRunner'
     }
 

--- a/S3TransferUtilitySample/build.gradle
+++ b/S3TransferUtilitySample/build.gradle
@@ -43,6 +43,11 @@ android {
         testInstrumentationRunner = 'android.support.test.runner.AndroidJUnitRunner'
     }
 
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
     lintOptions {
         abortOnError false
     }

--- a/S3TransferUtilitySample/src/com/amazonaws/demo/s3transferutility/DownloadActivity.java
+++ b/S3TransferUtilitySample/src/com/amazonaws/demo/s3transferutility/DownloadActivity.java
@@ -344,7 +344,6 @@ public class DownloadActivity extends ListActivity {
         });
 
         updateButtonAvailability();
-        requestWriteExternalStoragePermission();
     }
 
     @Override
@@ -366,46 +365,6 @@ public class DownloadActivity extends ListActivity {
         }
     }
 
-    private void  requestWriteExternalStoragePermission() {
-        //ask for the permission in android M
-        int permission = ContextCompat.checkSelfPermission(this,
-                Manifest.permission.WRITE_EXTERNAL_STORAGE);
-
-        if (permission != PackageManager.PERMISSION_GRANTED) {
-            Log.i(TAG, "Permission to store data in external storage is not granted");
-
-            if (ActivityCompat.shouldShowRequestPermissionRationale(this,
-                    Manifest.permission.WRITE_EXTERNAL_STORAGE)) {
-                AlertDialog.Builder builder = new AlertDialog.Builder(this);
-                builder.setMessage("Permission to access the External Storage is required for this application to store the downloaded data from Amazon S3")
-                        .setTitle("Permission required");
-
-                builder.setPositiveButton("OK", new DialogInterface.OnClickListener() {
-
-                    public void onClick(DialogInterface dialog, int id) {
-                        Log.i(TAG, "Clicked");
-                        makeRequest();
-                    }
-                });
-
-                AlertDialog dialog = builder.create();
-                dialog.show();
-
-            } else {
-                makeRequest();
-            }
-        }
-        else {
-            Log.i(TAG, "Permission to store data in external storage is granted.");
-        }
-
-    }
-    protected void makeRequest() {
-        ActivityCompat.requestPermissions(this,
-                new String[]{Manifest.permission.WRITE_EXTERNAL_STORAGE},
-                REQUEST_WRITE_STORAGE);
-    }
-
     /*
      * Begins to download the file specified by the key in the bucket.
      */
@@ -413,7 +372,7 @@ public class DownloadActivity extends ListActivity {
         // Location to download files from S3 to. You can choose any accessible
         // file.
 
-        File file = new File(Environment.getExternalStorageDirectory().toString() + "/" + key);
+        File file = new File(getExternalFilesDir(null).toString() + "/" + key);
 
         // Initiate the download
         TransferObserver observer = transferUtility.download(key, file);
@@ -434,7 +393,7 @@ public class DownloadActivity extends ListActivity {
     private void beginDownloadInBackground(String key) {
         // Location to download files from S3 to. You can choose any accessible
         // file.
-        File file = new File(Environment.getExternalStorageDirectory().toString() + "/" + key);
+        File file = new File(getExternalFilesDir(null).toString() + "/" + key);
 
         // Wrap the download call from a background service to
         // support long-running downloads. Uncomment the following

--- a/S3TransferUtilitySample/src/com/amazonaws/demo/s3transferutility/UploadActivity.java
+++ b/S3TransferUtilitySample/src/com/amazonaws/demo/s3transferutility/UploadActivity.java
@@ -531,9 +531,9 @@ public class UploadActivity extends ListActivity {
         try (
             Cursor cursor = getContentResolver().query(uri, projection, null, null, null);
         ){
-            int column_index = cursor.getColumnIndexOrThrow(MediaStore.Images.Media.DISPLAY_NAME);
+            int columnIndex = cursor.getColumnIndexOrThrow(MediaStore.Images.Media.DISPLAY_NAME);
             if (cursor.moveToFirst()) {
-                return cursor.getString(column_index);
+                return cursor.getString(columnIndex);
             }
         }
         // If the display name is not found for any reason, use the Uri path as a fallback.


### PR DESCRIPTION
*Issue #:* https://github.com/aws-amplify/aws-sdk-android/issues/1482

*Description of changes:*. 
 - Updates the targetSdkVersion to 29 for S3TransferUtilitySampleApp and account for changes to scoped storage changes.
 - Replaces usages of the deprecated [`Environment.getExternalStorageDirectory()`](https://developer.android.com/reference/android/os/Environment#getExternalStorageDirectory()) (i.e. `/storage/emulated/0/`) with `Context#getExternalFilesDir(String)`, which is an app specific (i.e. `/storage/emulated/0/Android/data/com.amazonaws.demo.s3transferutility/files/`).
 - Removes usage of deprecated [`MediaStore.Images.Media.DATA`](https://developer.android.com/reference/android/provider/MediaStore.MediaColumns#DATA).   This was being used to convert a Uri to a path, but this is no longer always possible as of API 29.
    - For `DownloadActivity.java`, files are now saved in the scoped storage folder.
    - For `UploadActivity.java`, it was a little more complicated.  The  system file picker returns a `Uri`.  As of API 29, we can't always get the path where this content is stored anymore, so instead, we copy the data from the `Uri` into a new `File` object in the app's scoped cache directory, and then pass this `File` to TransferUtility.  Note: A better solution would be to pass the Uri directly to TransferUtility, but there are no TransferUtility APIs with this (they require a File object), so it might make sense to add this functionality to `TransferUtility` at some point.
 - Removed `READ_EXTERNAL_STORAGE` and `WRITE_EXTERNAL_STORAGE` from the manifest, and removed the code which prompts the user for permission.  Since the app now only utilizes scoped storage, these permissions are no longer needed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.