### PR TITLE
Update to start foreground service for Android Oreo+

### DIFF
--- a/S3TransferUtilitySample/AndroidManifest.xml
+++ b/S3TransferUtilitySample/AndroidManifest.xml
@@ -5,6 +5,7 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
 
     <application
         android:name=".MyApplication"

--- a/S3TransferUtilitySample/res/values/strings.xml
+++ b/S3TransferUtilitySample/res/values/strings.xml
@@ -1,6 +1,9 @@
 <resources>
 
     <string name="app_name">S3TransferUtility</string>
+    <string name="channel_name">Transfer Service Channel</string>
+    <string name="notification_title">Transfer Service Notification</string>
+    <string name="notification_text">Transfer Service is running</string>
     <string name="upload_activity">UploadActivity</string>
     <string name="download_activity">DownloadActivity</string>
     <string name="download_selection_activity">Select a file from the bucket</string>

--- a/S3TransferUtilitySample/src/com/amazonaws/demo/s3transferutility/MyApplication.java
+++ b/S3TransferUtilitySample/src/com/amazonaws/demo/s3transferutility/MyApplication.java
@@ -1,18 +1,50 @@
 package com.amazonaws.demo.s3transferutility;
 
 import android.app.Application;
+import android.app.Notification;
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
+import android.app.PendingIntent;
 import android.content.Intent;
+import android.os.Build;
 
 import com.amazonaws.mobileconnectors.s3.transferutility.TransferService;
+
+import java.util.UUID;
 
 public class MyApplication extends Application {
     // Overriding this method is totally optional!
     @Override
     public void onCreate() {
         super.onCreate();
-        // Required initialization logic here!
 
-        // Network service
-        getApplicationContext().startService(new Intent(getApplicationContext(), TransferService.class));
+        Intent tsIntent = new Intent(this, TransferService.class);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            String id = UUID.randomUUID().toString();
+            String name = getString(R.string.channel_name);
+            int importance = NotificationManager.IMPORTANCE_DEFAULT;
+            PendingIntent pendingIntent = PendingIntent.getActivity(this, 0, tsIntent, 0);
+
+            // Notification manager to listen to a channel
+            NotificationChannel channel = new NotificationChannel(id, name, importance);
+            NotificationManager notificationManager = getSystemService(NotificationManager.class);
+            notificationManager.createNotificationChannel(channel);
+
+            // Valid notification object required
+            Notification notification = new Notification.Builder(this, id)
+                    .setContentTitle(getString(R.string.notification_title))
+                    .setContentText(getString(R.string.notification_text))
+                    .setContentIntent(pendingIntent)
+                    .build();
+
+            tsIntent.putExtra(TransferService.INTENT_KEY_NOTIFICATION, notification);
+            tsIntent.putExtra(TransferService.INTENT_KEY_NOTIFICATION_ID, 15);
+            tsIntent.putExtra(TransferService.INTENT_KEY_REMOVE_NOTIFICATION, true);
+
+            // Foreground service required starting from Android Oreo
+            startForegroundService(tsIntent);
+        } else {
+            startService(tsIntent);
+        }
     }
 }


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-amplify/aws-sdk-android/issues/1110
https://github.com/aws-amplify/aws-sdk-android/issues/1173
https://github.com/aws-amplify/aws-sdk-android/issues/1193

*Description of changes:*
[Android Oreo](https://developer.android.com/about/versions/oreo/background) began to enforce restrictions on background execution, requiring `TransferService` to be started as a foreground service. This has been a source of confusion for many, so sample app now includes sample code showing how to pass a valid notification object.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
