### PR TITLE
Update AWS SDK version to the current latest

### DIFF
--- a/AmazonKinesisVideoDemoApp/build.gradle
+++ b/AmazonKinesisVideoDemoApp/build.gradle
@@ -49,7 +49,7 @@ repositories {
 
 
 dependencies {
-    def aws_version = '2.30.+'
+    def aws_version = '2.36.+'
 
     implementation ("com.amazonaws:aws-android-sdk-kinesisvideo:$aws_version@aar") { transitive = true }
     implementation ("com.amazonaws:aws-android-sdk-mobile-client:$aws_version@aar") { transitive = true }

--- a/AmazonKinesisVideoDemoApp/build.gradle
+++ b/AmazonKinesisVideoDemoApp/build.gradle
@@ -49,7 +49,7 @@ repositories {
 
 
 dependencies {
-    def aws_version = '2.36.+'
+    def aws_version = '2.52.+'
 
     implementation ("com.amazonaws:aws-android-sdk-kinesisvideo:$aws_version@aar") { transitive = true }
     implementation ("com.amazonaws:aws-android-sdk-mobile-client:$aws_version@aar") { transitive = true }


### PR DESCRIPTION
Update AWS SDK version to the current latest 2.36.+ to avoid `Failed to get setter method id` error in Kinesis Video demo app.

*Issue #, if available:*
When used with AWS SDK version 2.30.+, the Kinesis Video demo app throws `Failed to get setter method id` error and fails to send video data to the cloud. This issue has been fixed in https://github.com/aws-amplify/aws-sdk-android/pull/2611 in the AWS SDK.

*Description of changes:*
Update AWS SDK version to the current latest 2.36.+ in Kinesis Video demo app.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
